### PR TITLE
feat: adds ENV VAR to configure local_ranges in config.ini

### DIFF
--- a/apps/sabnzbd/entrypoint.sh
+++ b/apps/sabnzbd/entrypoint.sh
@@ -8,13 +8,13 @@ if [[ ! -f "/config/sabnzbd.ini" ]]; then
     printf "Creating api keys ...\n"
     api_key=$(tr -dc 'a-z0-9' < /dev/urandom | fold -w 32 | head -n 1)
     nzb_key=$(tr -dc 'a-z0-9' < /dev/urandom | fold -w 32 | head -n 1)
-    sed -i -e "s/^api_key *=.*$/api_key = ${api_key}/g" /config/sabnzbd.ini
-    sed -i -e "s/^nzb_key *=.*$/nzb_key = ${nzb_key}/g" /config/sabnzbd.ini
+    sed -i -e "s|^api_key *=.*$|api_key = ${api_key}|g" /config/sabnzbd.ini
+    sed -i -e "s|^nzb_key *=.*$|nzb_key = ${nzb_key}|g" /config/sabnzbd.ini
 fi
 
-[[ -n "${SABNZBD__API_KEY}" ]] && sed -i -e "s/^api_key *=.*$/api_key = ${SABNZBD__API_KEY}/g" /config/sabnzbd.ini
-[[ -n "${SABNZBD__NZB_KEY}" ]] && sed -i -e "s/^nzb_key *=.*$/nzb_key = ${SABNZBD__NZB_KEY}/g" /config/sabnzbd.ini
-[[ -n "${SABNZBD__HOST_WHITELIST_ENTRIES}" ]] && sed -i -e "s/^host_whitelist *=.*$/host_whitelist = ${HOSTNAME:-sabnzbd}, ${SABNZBD__HOST_WHITELIST_ENTRIES}/g" /config/sabnzbd.ini
+[[ -n "${SABNZBD__API_KEY}" ]] && sed -i -e "s|^api_key *=.*$|api_key = ${SABNZBD__API_KEY}|g" /config/sabnzbd.ini
+[[ -n "${SABNZBD__NZB_KEY}" ]] && sed -i -e "s|^nzb_key *=.*$|nzb_key = ${SABNZBD__NZB_KEY}|g" /config/sabnzbd.ini
+[[ -n "${SABNZBD__HOST_WHITELIST_ENTRIES}" ]] && sed -i -e "s|^host_whitelist *=.*$|host_whitelist = ${HOSTNAME:-sabnzbd}, ${SABNZBD__HOST_WHITELIST_ENTRIES}|g" /config/sabnzbd.ini
 [[ -n "${SABNZBD__LOCAL_RANGES_ENTRIES}" ]] && sed -i -e "s|^local_ranges *=.*$|local_ranges = ${SABNZBD__LOCAL_RANGES_ENTRIES}|g" /config/sabnzbd.ini
 
 exec \

--- a/apps/sabnzbd/entrypoint.sh
+++ b/apps/sabnzbd/entrypoint.sh
@@ -15,6 +15,7 @@ fi
 [[ -n "${SABNZBD__API_KEY}" ]] && sed -i -e "s/^api_key *=.*$/api_key = ${SABNZBD__API_KEY}/g" /config/sabnzbd.ini
 [[ -n "${SABNZBD__NZB_KEY}" ]] && sed -i -e "s/^nzb_key *=.*$/nzb_key = ${SABNZBD__NZB_KEY}/g" /config/sabnzbd.ini
 [[ -n "${SABNZBD__HOST_WHITELIST_ENTRIES}" ]] && sed -i -e "s/^host_whitelist *=.*$/host_whitelist = ${HOSTNAME:-sabnzbd}, ${SABNZBD__HOST_WHITELIST_ENTRIES}/g" /config/sabnzbd.ini
+[[ -n "${SABNZBD__LOCAL_RANGES_ENTRIES}" ]] && sed -i -e "s/^local_ranges *=.*$/local_ranges = ${SABNZBD__LOCAL_RANGES_ENTRIES}/g" /config/sabnzbd.ini
 
 exec \
     /usr/local/bin/python \

--- a/apps/sabnzbd/entrypoint.sh
+++ b/apps/sabnzbd/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 [[ -n "${SABNZBD__API_KEY}" ]] && sed -i -e "s/^api_key *=.*$/api_key = ${SABNZBD__API_KEY}/g" /config/sabnzbd.ini
 [[ -n "${SABNZBD__NZB_KEY}" ]] && sed -i -e "s/^nzb_key *=.*$/nzb_key = ${SABNZBD__NZB_KEY}/g" /config/sabnzbd.ini
 [[ -n "${SABNZBD__HOST_WHITELIST_ENTRIES}" ]] && sed -i -e "s/^host_whitelist *=.*$/host_whitelist = ${HOSTNAME:-sabnzbd}, ${SABNZBD__HOST_WHITELIST_ENTRIES}/g" /config/sabnzbd.ini
-[[ -n "${SABNZBD__LOCAL_RANGES_ENTRIES}" ]] && sed -i -e "s/^local_ranges *=.*$/local_ranges = ${SABNZBD__LOCAL_RANGES_ENTRIES}/g" /config/sabnzbd.ini
+[[ -n "${SABNZBD__LOCAL_RANGES_ENTRIES}" ]] && sed -i -e "s|^local_ranges *=.*$|local_ranges = ${SABNZBD__LOCAL_RANGES_ENTRIES}|g" /config/sabnzbd.ini
 
 exec \
     /usr/local/bin/python \


### PR DESCRIPTION
## Description of Changes

Maps entries in `SABNZBD__LOCAL_RANGES_ENTRIES` to the `local_ranges` config option in `sabnzbd.ini`.

Fixes access from  RFC 6598 ip ranges used in some Kubernetes deployments.

## Motivation:

[RFC 6598 IP ranges](https://en.wikipedia.org/wiki/Carrier-grade_NAT#Shared_address_space) are sometimes used in Kubernetes deployments to allocate IP space to the pod network that does not overlap with existing on-prem network addressing. In my case, I have used the 100.64.0.0/16 range for my pod network.

SABnzbd  maintains some internal list of "private" networks, and by default it refuses requests from CIDRs outside of that list. This behavior can be overriden by configuring the `local_ranges` option, but for users deploying the app to Kubernetes, this means jumping through additional hoops.

Adding this option to this container would allow the users to configure their network range, so that they can log in and perform the initial setup.

## Comments

I named the VAR `SABNZBD__LOCAL_RANGES_ENTRIES` to follow the existing convention from `SABNZBD__HOST_WHITELIST_ENTRIES`, feel free to shorten it to `SABNZBD__LOCAL_RANGES`.